### PR TITLE
Fix visualizers switching issue

### DIFF
--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
@@ -56,9 +56,9 @@ final class Constants {
     static final int COLOR_OFFSET          = 3;
     static final int COLOR_DATA_SIZE       = 4;
 
-
     /** Vis2 constants */
     static final int VIS2_STRIDE_BYTES = (POSITION_DATA_SIZE + COLOR_DATA_SIZE) * BYTES_PER_FLOAT;
+
     /** GLDot constants for Vis2*/
     static final int DOT_HEIGHT = 600;
     static final int DOT_WIDTH  = 600;
@@ -75,8 +75,8 @@ final class Constants {
     static final float PIXEL = 0.016f;
     static final float AMPLIFIER = 1.0f;
 
-
     /** VisualizerModel constants */
     static final String MODEL_TAG = "MODEL_TAG";
+    static final int SWITCH_VIS_TIME = 2000;   //Amount of time to switch from the first visualizer to the second.
 
 }

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
@@ -2,16 +2,14 @@ package com.example.colecofer.android_audio_visualizer;
 
 final class Constants {
 
-
     /** GLCircle constants */
     static final int COUNT = 364;
-
 
     /** GLLine constants */
     static final int BYTES_PER_FLOAT = 4;
 
     /** Visualizer Switching */
-    static final boolean SHOULD_SWITCH_VIS = false;    //Set to false if you do not want to rotate visualizers
+    static final boolean SHOULD_SWITCH_VIS = true;    //Set to false if you do not want to rotate visualizers
     static final int SWITCH_VIS_TIME = 2000;          //Amount of time to switch from the first visualizer to the second.
 
     /** MainActivity constants */

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
@@ -43,6 +43,8 @@ final class Constants {
     static final long REFRESH_DECIBEL_TIME = 16L;
     static final float MAX_DECIBEL_RATIO   = 1.0f;
 
+    /** Shared Visualizer Constants **/
+
 
     /** Vis1 constants */
     static final int LINE_AMT              = 15;                  //Number of lines to display on the screen

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
@@ -44,7 +44,10 @@ final class Constants {
     static final float MAX_DECIBEL_RATIO   = 1.0f;
 
     /** Shared Visualizer Constants **/
-
+    static final String GLSL_POSITION_HANDLE = "a_Position";
+    static final String GLSL_COLOR_HANDLE = "a_Color";
+    static final String GLSL_DB_LEVEL = "a_DB_Level";
+    static final String GLSL_TIME = "time";
 
     /** Vis1 constants */
     static final int LINE_AMT              = 15;                  //Number of lines to display on the screen

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
@@ -10,7 +10,7 @@ final class Constants {
 
     /** Visualizer Switching */
     static final boolean SHOULD_SWITCH_VIS = true;    //Set to false if you do not want to rotate visualizers
-    static final int SWITCH_VIS_TIME = 2000;          //Amount of time to switch from the first visualizer to the second.
+    static final int SWITCH_VIS_TIME = 3000;          //Amount of time to switch from the first visualizer to the second.
 
     /** MainActivity constants */
     //TODO: This is Spotify's test account because I don't want to hard code ours into a public repository...

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/Constants.java
@@ -10,6 +10,9 @@ final class Constants {
     /** GLLine constants */
     static final int BYTES_PER_FLOAT = 4;
 
+    /** Visualizer Switching */
+    static final boolean SHOULD_SWITCH_VIS = false;    //Set to false if you do not want to rotate visualizers
+    static final int SWITCH_VIS_TIME = 2000;          //Amount of time to switch from the first visualizer to the second.
 
     /** MainActivity constants */
     //TODO: This is Spotify's test account because I don't want to hard code ours into a public repository...
@@ -64,7 +67,7 @@ final class Constants {
     /** Vis2 constants */
     static final int VIS2_STRIDE_BYTES = (POSITION_DATA_SIZE + COLOR_DATA_SIZE) * BYTES_PER_FLOAT;
 
-    /** GLDot constants for Vis2*/
+    /** GLDot constants for Vis2 */
     static final int DOT_HEIGHT = 600;
     static final int DOT_WIDTH  = 600;
     static final int DOT_COUNT  = DOT_WIDTH * DOT_HEIGHT;
@@ -82,6 +85,5 @@ final class Constants {
 
     /** VisualizerModel constants */
     static final String MODEL_TAG = "MODEL_TAG";
-    static final int SWITCH_VIS_TIME = 2000;   //Amount of time to switch from the first visualizer to the second.
 
 }

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/Utility.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/Utility.java
@@ -25,12 +25,12 @@ public class Utility {
      */
     public Utility() {}
 
-    /**
-     * Pass context for connecting Resource
-     *
-     * @param context
-     */
-    public Utility(Context context) {
+  /**
+   * Pass context for connecting Resource
+   *
+   *context* *
+   */
+  public Utility(Context context) {
         this.context = context;
     }
 

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
@@ -41,14 +41,11 @@ public class VisOne extends VisualizerBase {
     }
 
     /**
-     * Initialization during
-     * @param positionHandle
-     * @param colorHandle
+     * Initialization of handles during onSurfaceCreated in VisualizerRenderer
      */
     public void initOnSurfaceCreated(int positionHandle, int colorHandle) {
         this.positionHandle = positionHandle;
         this.colorHandle = colorHandle;
-
     }
 
     @Override

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
@@ -23,7 +23,7 @@ public class VisOne extends VisualizerBase {
      * Constructor
      */
     public VisOne(Context context) {
-        // Set up line array class
+        this.visNum = 1;
         this.lines = new GLLine[LINE_AMT];
 
         float k = LEFT_DRAW_BOUNDARY;

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
@@ -11,8 +11,6 @@ import static com.example.colecofer.android_audio_visualizer.Constants.RIGHT_DRA
  * updateVertices() and draw() methods so that openGL can
  * render it's contents.
  * */
-
-//public class VisOne extends VisualizerBase {
 public class VisOne extends VisualizerBase {
 
     private GLLine[] lines;  //Holds the lines to be displayed
@@ -54,7 +52,6 @@ public class VisOne extends VisualizerBase {
             lines[i].updateVertices();
         }
     }
-
 
     /**
      * Calls line's draw call

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisOne.java
@@ -41,9 +41,16 @@ public class VisOne extends VisualizerBase {
     }
 
     /**
-     * Updates all the lines.
-     * No need for argument because decibel is static member
+     * Initialization during
+     * @param positionHandle
+     * @param colorHandle
      */
+    public void initOnSurfaceCreated(int positionHandle, int colorHandle) {
+        this.positionHandle = positionHandle;
+        this.colorHandle = colorHandle;
+
+    }
+
     @Override
     public void updateVertices() {
         for(int i = 0; i < LINE_AMT; i++){
@@ -51,11 +58,6 @@ public class VisOne extends VisualizerBase {
         }
     }
 
-//    public void updateVertices(float[] newVertices) {
-//        for(int i = 0; i < LINE_AMT; i++){
-//            lines[i].updateVertices();
-//        }
-//    }
 
     /**
      * Calls line's draw call

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisThree.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisThree.java
@@ -8,6 +8,14 @@ public class VisThree extends VisualizerBase {
         this.visNum = 3;
     }
 
+    /**
+     * Initialization of handles during onSurfaceCreated in VisualizerRenderer
+     */
+    public void initOnSurfaceCreated(int positionHandle, int colorHandle) {
+        this.positionHandle = positionHandle;
+        this.colorHandle = colorHandle;
+    }
+
     @Override
     public void updateVertices() {
 

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisThree.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisThree.java
@@ -1,6 +1,12 @@
 package com.example.colecofer.android_audio_visualizer;
 
+import android.content.Context;
+
 public class VisThree extends VisualizerBase {
+
+    public VisThree(Context context) {
+        this.visNum = 3;
+    }
 
     @Override
     public void updateVertices() {

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisTwo.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisTwo.java
@@ -2,6 +2,7 @@ package com.example.colecofer.android_audio_visualizer;
 
 import android.content.Context;
 import android.opengl.GLES20;
+import android.util.Log;
 
 import java.nio.FloatBuffer;
 import static com.example.colecofer.android_audio_visualizer.Constants.COLOR_DATA_SIZE;

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisTwo.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisTwo.java
@@ -23,6 +23,7 @@ public class VisTwo extends VisualizerBase {
      * @param context
      */
     public VisTwo(Context context) {
+        this.visNum = 2;
         util = new Utility(context);
         dot = new GLDot();
 

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisTwo.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisTwo.java
@@ -8,6 +8,8 @@ import java.nio.FloatBuffer;
 import static com.example.colecofer.android_audio_visualizer.Constants.COLOR_DATA_SIZE;
 import static com.example.colecofer.android_audio_visualizer.Constants.COLOR_OFFSET;
 import static com.example.colecofer.android_audio_visualizer.Constants.DOT_COUNT;
+import static com.example.colecofer.android_audio_visualizer.Constants.GLSL_DB_LEVEL;
+import static com.example.colecofer.android_audio_visualizer.Constants.GLSL_TIME;
 import static com.example.colecofer.android_audio_visualizer.Constants.POSITION_DATA_SIZE;
 import static com.example.colecofer.android_audio_visualizer.Constants.POSITION_OFFSET;
 import static com.example.colecofer.android_audio_visualizer.Constants.VIS2_STRIDE_BYTES;
@@ -32,6 +34,16 @@ public class VisTwo extends VisualizerBase {
         this.fragmentShader = util.getStringFromGLSL(R.raw.vistwofragment);
 
         visTwoStartTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Initialization of handles during onSurfaceCreated in VisualizerRenderer
+     */
+    public void initOnSurfaceCreated(int positionHandle, int colorHandle, int programHandle) {
+        this.positionHandle = positionHandle;
+        this.colorHandle = colorHandle;
+        this.currentDecibelLevelHandle = GLES20.glGetUniformLocation(programHandle, GLSL_DB_LEVEL);
+        this.timeHandle = GLES20.glGetUniformLocation(programHandle, GLSL_TIME);
     }
 
     @Override

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerActivity.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerActivity.java
@@ -36,7 +36,7 @@ public class VisualizerActivity extends AppCompatActivity implements Visualizer.
     private long previousUpdateTime;
     static ArrayDeque<Float> decibelHistory;
 
-    private MediaPlayer mediaPlayer;
+    static MediaPlayer mediaPlayer;
     private Visualizer visualizer;
     private VisualizerSurfaceView surfaceView;
     private VisualizerRenderer visualizerRenderer;

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerBase.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerBase.java
@@ -1,5 +1,7 @@
 package com.example.colecofer.android_audio_visualizer;
 
+import android.opengl.GLES20;
+
 /**
  * VisualizerBase is the fundamental abstract class that all visualizers should
  * be derived from. This way, we can have an object of this base class
@@ -14,6 +16,7 @@ abstract public class VisualizerBase {
     protected int currentDecibelLevelHandle;
     protected int currentFragmentDecibelLevelHandle;
     protected int timeHandle;
+    int visNum;  //A unique integer value to represent each visualizer
 
     protected int fftArraySize;
     protected String vertexShader;
@@ -60,6 +63,16 @@ abstract public class VisualizerBase {
 
 
     public void setCurrentFragmentDecibelLevelHandle(int currentDecibelLevel) { this.currentFragmentDecibelLevelHandle = currentDecibelLevel; }
+
+
+    /**
+     * Resets the position and color handle.
+     * This is useful for when switching visualizers during track playback.
+     */
+    public void disableVertexAttribArrays() {
+        GLES20.glDisableVertexAttribArray(positionHandle);
+        GLES20.glDisableVertexAttribArray(colorHandle);
+    }
 
     public void setTimeHandle(int timeHandle) { this.timeHandle = timeHandle; }
 

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
@@ -1,6 +1,7 @@
 package com.example.colecofer.android_audio_visualizer;
 
 import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.graphics.Color;
 import android.util.Log;
 import com.spotify.sdk.android.player.PlaybackState;
@@ -47,6 +48,18 @@ public class VisualizerModel {
 
 
     /**
+     * Initialize the visualizers passing it the context.
+     * They need the context for importing the glsl files.
+     * This may not be optimal, but it's the only we found successful.
+     * @param context The context for VisualizerSurfaceView
+     */
+    public void initVisualizers(Context context) {
+        this.visOne = new VisOne(context);
+        this.visTwo = new VisTwo(context);
+        this.visThree = new VisThree(context);
+    }
+
+    /**
      * Allows access to the VisualizerModel Singleton outside of class scope.
      * @return The VisualizerModel singleton
      */
@@ -89,14 +102,15 @@ public class VisualizerModel {
     public void checkToSwitchVisualizer() {
         float currentTimeMillis = VisualizerActivity.mediaPlayer.getCurrentPosition();
         if (currentTimeMillis >= visualizerSwitchTimeOne && currentVisualizer.visNum == 1) {
-            currentVisualizer.disableVertexAttribArrays();
-            currentVisualizer = new VisTwo(VisualizerSurfaceView.context);
+            this.currentVisualizer.disableVertexAttribArrays();
+            this.currentVisualizer = this.visTwo;
+//            currentVisualizer = new VisTwo();
         }
 
         //TODO: Uncomment this when visualizer three is ready
         //else if (currentTimeMillis >= visualizerSwitchTimeTwo && currentVisualizer.visNum == 2) {
         //   currentVisualizer.disableVertexAttribArrays();
-        //    currentVisualizer = new VisThree(VisualizerSurfaceView.context);
+        //    currentVisualizer = new VisThree();
         //}
     }
 

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
@@ -2,7 +2,6 @@ package com.example.colecofer.android_audio_visualizer;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.graphics.Color;
 import android.util.Log;
 import com.spotify.sdk.android.player.PlaybackState;
 import com.spotify.sdk.android.player.SpotifyPlayer;
@@ -104,6 +103,7 @@ public class VisualizerModel {
         if (currentTimeMillis >= visualizerSwitchTimeOne && currentVisualizer.visNum == 1) {
             this.currentVisualizer.disableVertexAttribArrays();
             this.currentVisualizer = this.visTwo;
+            VisualizerRenderer.initShaders();
         }
 
         //TODO: Uncomment this when visualizer three is ready

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
@@ -59,6 +59,39 @@ public class VisualizerModel {
     }
 
     /**
+     * Checks if it's time to switch visualizers, and if it's time
+     * then changes currentVisualizer to the new visualizer
+     */
+    //TODO: This will only work with local files since it's based off the media player
+    public void checkToSwitchVisualizer() {
+        float currentTimeMillis = VisualizerActivity.mediaPlayer.getCurrentPosition();
+        if (currentTimeMillis >= visualizerSwitchTimeOne && currentVisualizer.visNum == 1) {
+            this.currentVisualizer.disableVertexAttribArrays();
+            this.currentVisualizer = this.visTwo;
+            VisualizerRenderer.initShaders();
+        }
+
+        //TODO: Uncomment this when visualizer three is ready
+        //else if (currentTimeMillis >= visualizerSwitchTimeTwo && currentVisualizer.visNum == 2) {
+        //   currentVisualizer.disableVertexAttribArrays();
+        //   currentVisualizer = new VisThree();
+        //   VisualizerRenderer.initShaders();
+        //}
+    }
+
+    /**
+     * Sets the times to switch visualizers
+     * @param duration The length of the track in milliseconds
+     */
+    public void setDuration(int duration) {
+        //TODO: This is temporarily being set to a constant defined in constants.java for debugging convenience
+        this.visualizerSwitchTimeOne = SWITCH_VIS_TIME;
+        //durationInMilliseconds = duration;
+        //visualizerSwitchTimeOne = duration / 3;
+        //visualizerSwitchTimeTwo = visualizerSwitchTimeOne * 2;
+    }
+
+    /**
      * Allows access to the VisualizerModel Singleton outside of class scope.
      * @return The VisualizerModel singleton
      */
@@ -91,38 +124,6 @@ public class VisualizerModel {
 
         this.colorMatrix[3] = 1;
 
-    }
-
-    /**
-     * Checks if it's time to switch visualizers, and if it's time
-     * then changes currentVisualizer to the new visualizer
-     */
-    //TODO: This will only work with local files since it's based off the media player
-    public void checkToSwitchVisualizer() {
-        float currentTimeMillis = VisualizerActivity.mediaPlayer.getCurrentPosition();
-        if (currentTimeMillis >= visualizerSwitchTimeOne && currentVisualizer.visNum == 1) {
-            this.currentVisualizer.disableVertexAttribArrays();
-            this.currentVisualizer = this.visTwo;
-            VisualizerRenderer.initShaders();
-        }
-
-        //TODO: Uncomment this when visualizer three is ready
-        //else if (currentTimeMillis >= visualizerSwitchTimeTwo && currentVisualizer.visNum == 2) {
-        //   currentVisualizer.disableVertexAttribArrays();
-        //    currentVisualizer = new VisThree();
-        //}
-    }
-
-    /**
-     * Sets the times to switch visualizers
-     * @param duration The length of the track in milliseconds
-     */
-    public void setDuration(int duration) {
-        //TODO: This is temporarily being set to a constant defined in constants.java until things are working properly
-        this.visualizerSwitchTimeOne = SWITCH_VIS_TIME;
-        //durationInMilliseconds = duration;
-        //visualizerSwitchTimeOne = duration / 3;
-        //visualizerSwitchTimeTwo = visualizerSwitchTimeOne * 2;
     }
 
     /**

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
@@ -104,7 +104,6 @@ public class VisualizerModel {
         if (currentTimeMillis >= visualizerSwitchTimeOne && currentVisualizer.visNum == 1) {
             this.currentVisualizer.disableVertexAttribArrays();
             this.currentVisualizer = this.visTwo;
-//            currentVisualizer = new VisTwo();
         }
 
         //TODO: Uncomment this when visualizer three is ready

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
@@ -29,6 +29,11 @@ public class VisualizerModel {
     public static VisualizerRenderer renderer;         //TODO: Consider making these private
     public static VisualizerBase currentVisualizer;
 
+    //Visualizer objects that the this.currentVisualizer object will point at
+    public VisOne visOne;
+    public VisTwo visTwo;
+    public VisThree visThree;
+
     /**
      * Default Constructor
      */

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerModel.java
@@ -7,6 +7,7 @@ import com.spotify.sdk.android.player.PlaybackState;
 import com.spotify.sdk.android.player.SpotifyPlayer;
 
 import static com.example.colecofer.android_audio_visualizer.Constants.MODEL_TAG;
+import static com.example.colecofer.android_audio_visualizer.Constants.SWITCH_VIS_TIME;
 
 public class VisualizerModel {
 
@@ -75,10 +76,35 @@ public class VisualizerModel {
 
     }
 
+    /**
+     * Checks if it's time to switch visualizers, and if it's time
+     * then changes currentVisualizer to the new visualizer
+     */
+    //TODO: This will only work with local files since it's based off the media player
+    public void checkToSwitchVisualizer() {
+        float currentTimeMillis = VisualizerActivity.mediaPlayer.getCurrentPosition();
+        if (currentTimeMillis >= visualizerSwitchTimeOne && currentVisualizer.visNum == 1) {
+            currentVisualizer.disableVertexAttribArrays();
+            currentVisualizer = new VisTwo(VisualizerSurfaceView.context);
+        }
+
+        //TODO: Uncomment this when visualizer three is ready
+        //else if (currentTimeMillis >= visualizerSwitchTimeTwo && currentVisualizer.visNum == 2) {
+        //   currentVisualizer.disableVertexAttribArrays();
+        //    currentVisualizer = new VisThree(VisualizerSurfaceView.context);
+        //}
+    }
+
+    /**
+     * Sets the times to switch visualizers
+     * @param duration The length of the track in milliseconds
+     */
     public void setDuration(int duration) {
-        durationInMilliseconds = duration;
-        visualizerSwitchTimeOne = duration / 3;
-        visualizerSwitchTimeTwo = visualizerSwitchTimeOne * 2;
+        //TODO: This is temporarily being set to a constant defined in constants.java until things are working properly
+        this.visualizerSwitchTimeOne = SWITCH_VIS_TIME;
+        //durationInMilliseconds = duration;
+        //visualizerSwitchTimeOne = duration / 3;
+        //visualizerSwitchTimeTwo = visualizerSwitchTimeOne * 2;
     }
 
     /**

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
@@ -20,7 +20,12 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
         initShaders();
     }
 
-
+    /**
+     * This is separated from onSurfaceCreated because it needs to be called when
+     * a visualizer switches.
+     * This could be refactored, because currently each visualizer will be initialized
+     * when a visualizer switches which is unnecessary.
+     */
     public static void initShaders() {
         /** Locals to catch the index for glsl variables */
         int positionHandle;
@@ -112,11 +117,6 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
         gl.glViewport(0, 0, width, height);
     }
 
-    //Was newFftData
-//    public void updateVertices(float[] newVertices) {
-//        VisualizerModel.getInstance().currentVisualizer.updateVertices(newVertices);
-//
-//    }
 
     @Override
     public void onDrawFrame(GL10 gl) {

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
@@ -122,6 +122,7 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
 
     @Override
     public void onDrawFrame(GL10 gl) {
+        VisualizerModel.getInstance().checkToSwitchVisualizer();
         GLES20.glClear(GLES20.GL_DEPTH_BUFFER_BIT | GLES20.GL_COLOR_BUFFER_BIT);
         VisualizerModel.getInstance().currentVisualizer.draw();
     }

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
@@ -11,6 +11,7 @@ import javax.microedition.khronos.opengles.GL10;
 
 import static com.example.colecofer.android_audio_visualizer.Constants.GLSL_COLOR_HANDLE;
 import static com.example.colecofer.android_audio_visualizer.Constants.GLSL_POSITION_HANDLE;
+import static com.example.colecofer.android_audio_visualizer.Constants.SHOULD_SWITCH_VIS;
 
 public class VisualizerRenderer implements GLSurfaceView.Renderer {
 
@@ -23,8 +24,6 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
         /** Locals to catch the index for glsl variables */
         int positionHandle;
         int colorHandle;
-        int currentDecibelLevelHandle;
-        int timeHandle;
 
         GLES20.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
@@ -99,18 +98,10 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
         colorHandle = GLES20.glGetAttribLocation(programHandle, GLSL_COLOR_HANDLE);
 
 
+        //Initialize and handles to each specific visualizers
         VisualizerModel.getInstance().visOne.initOnSurfaceCreated(positionHandle, colorHandle);
         VisualizerModel.getInstance().visTwo.initOnSurfaceCreated(positionHandle, colorHandle, programHandle);
-
-//        if (VisualizerModel.getInstance().currentVisualizer instanceof VisTwo) {
-//            currentDecibelLevelHandle = GLES20.glGetUniformLocation(programHandle, "a_DB_Level");
-//            VisualizerModel.getInstance().currentVisualizer.setCurrentDecibelLevelHandle(currentDecibelLevelHandle);
-//            timeHandle = GLES20.glGetUniformLocation(programHandle, "time");
-//            VisualizerModel.getInstance().currentVisualizer.setTimeHandle(timeHandle);
-//        }
-
-//        VisualizerModel.getInstance().currentVisualizer.setPositionHandle(positionHandle);
-//        VisualizerModel.getInstance().currentVisualizer.setColorHandle(colorHandle);
+        //VisualizerModel.getInstance().visThree.initOnSurfaceCreated();
 
         // Tell OpenGL to use this program when rendering.
         GLES20.glUseProgram(programHandle);
@@ -129,7 +120,11 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
 
     @Override
     public void onDrawFrame(GL10 gl) {
-        VisualizerModel.getInstance().checkToSwitchVisualizer();
+
+        if (SHOULD_SWITCH_VIS == true) {
+            VisualizerModel.getInstance().checkToSwitchVisualizer();
+        }
+
         GLES20.glClear(GLES20.GL_DEPTH_BUFFER_BIT | GLES20.GL_COLOR_BUFFER_BIT);
         VisualizerModel.getInstance().currentVisualizer.draw();
     }

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
@@ -95,6 +95,9 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
         positionHandle = GLES20.glGetAttribLocation(programHandle, "a_Position");
         colorHandle = GLES20.glGetAttribLocation(programHandle, "a_Color");
 
+
+        VisualizerModel.getInstance().visOne.initOnSurfaceCreated(positionHandle, colorHandle);
+
         if (VisualizerModel.getInstance().currentVisualizer instanceof VisTwo) {
             currentDecibelLevelHandle = GLES20.glGetUniformLocation(programHandle, "a_DB_Level");
             VisualizerModel.getInstance().currentVisualizer.setCurrentDecibelLevelHandle(currentDecibelLevelHandle);

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
@@ -17,6 +17,11 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
 
     @Override
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
+        initShaders();
+    }
+
+
+    public static void initShaders() {
         /** Locals to catch the index for glsl variables */
         int positionHandle;
         int colorHandle;

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
@@ -9,6 +9,9 @@ import java.nio.IntBuffer;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
+import static com.example.colecofer.android_audio_visualizer.Constants.GLSL_COLOR_HANDLE;
+import static com.example.colecofer.android_audio_visualizer.Constants.GLSL_POSITION_HANDLE;
+
 public class VisualizerRenderer implements GLSurfaceView.Renderer {
 
     public VisualizerRenderer() {
@@ -73,8 +76,8 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
             GLES20.glAttachShader(programHandle, fragmentShaderHandle);
 
             // Bind position and color attributes
-            GLES20.glBindAttribLocation(programHandle, 0, "a_Position");
-            GLES20.glBindAttribLocation(programHandle, 1, "a_Color");
+            GLES20.glBindAttribLocation(programHandle, 0, GLSL_POSITION_HANDLE);
+            GLES20.glBindAttribLocation(programHandle, 1, GLSL_COLOR_HANDLE);
 
             // Link the two shaders together into a program.
             GLES20.glLinkProgram(programHandle);
@@ -92,21 +95,22 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
         }
 
         //Get the position and color attributes
-        positionHandle = GLES20.glGetAttribLocation(programHandle, "a_Position");
-        colorHandle = GLES20.glGetAttribLocation(programHandle, "a_Color");
+        positionHandle = GLES20.glGetAttribLocation(programHandle, GLSL_POSITION_HANDLE);
+        colorHandle = GLES20.glGetAttribLocation(programHandle, GLSL_COLOR_HANDLE);
 
 
         VisualizerModel.getInstance().visOne.initOnSurfaceCreated(positionHandle, colorHandle);
+        VisualizerModel.getInstance().visTwo.initOnSurfaceCreated(positionHandle, colorHandle, programHandle);
 
-        if (VisualizerModel.getInstance().currentVisualizer instanceof VisTwo) {
-            currentDecibelLevelHandle = GLES20.glGetUniformLocation(programHandle, "a_DB_Level");
-            VisualizerModel.getInstance().currentVisualizer.setCurrentDecibelLevelHandle(currentDecibelLevelHandle);
-            timeHandle = GLES20.glGetUniformLocation(programHandle, "time");
-            VisualizerModel.getInstance().currentVisualizer.setTimeHandle(timeHandle);
-        }
+//        if (VisualizerModel.getInstance().currentVisualizer instanceof VisTwo) {
+//            currentDecibelLevelHandle = GLES20.glGetUniformLocation(programHandle, "a_DB_Level");
+//            VisualizerModel.getInstance().currentVisualizer.setCurrentDecibelLevelHandle(currentDecibelLevelHandle);
+//            timeHandle = GLES20.glGetUniformLocation(programHandle, "time");
+//            VisualizerModel.getInstance().currentVisualizer.setTimeHandle(timeHandle);
+//        }
 
-        VisualizerModel.getInstance().currentVisualizer.setPositionHandle(positionHandle);
-        VisualizerModel.getInstance().currentVisualizer.setColorHandle(colorHandle);
+//        VisualizerModel.getInstance().currentVisualizer.setPositionHandle(positionHandle);
+//        VisualizerModel.getInstance().currentVisualizer.setColorHandle(colorHandle);
 
         // Tell OpenGL to use this program when rendering.
         GLES20.glUseProgram(programHandle);

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerRenderer.java
@@ -15,10 +15,6 @@ import static com.example.colecofer.android_audio_visualizer.Constants.SHOULD_SW
 
 public class VisualizerRenderer implements GLSurfaceView.Renderer {
 
-    public VisualizerRenderer() {
-
-    }
-
     @Override
     public void onSurfaceCreated(GL10 gl, EGLConfig config) {
         /** Locals to catch the index for glsl variables */
@@ -97,11 +93,10 @@ public class VisualizerRenderer implements GLSurfaceView.Renderer {
         positionHandle = GLES20.glGetAttribLocation(programHandle, GLSL_POSITION_HANDLE);
         colorHandle = GLES20.glGetAttribLocation(programHandle, GLSL_COLOR_HANDLE);
 
-
         //Initialize and handles to each specific visualizers
         VisualizerModel.getInstance().visOne.initOnSurfaceCreated(positionHandle, colorHandle);
         VisualizerModel.getInstance().visTwo.initOnSurfaceCreated(positionHandle, colorHandle, programHandle);
-        //VisualizerModel.getInstance().visThree.initOnSurfaceCreated();
+        VisualizerModel.getInstance().visThree.initOnSurfaceCreated(positionHandle, colorHandle);
 
         // Tell OpenGL to use this program when rendering.
         GLES20.glUseProgram(programHandle);

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerSurfaceView.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerSurfaceView.java
@@ -7,9 +7,7 @@ import android.util.AttributeSet;
 
 public class VisualizerSurfaceView extends GLSurfaceView {
 
-//    private static float density;
-
-    static Context context;
+    private Context context; //This exists so that we can read in the glsl files
 
     public VisualizerSurfaceView(Context context) {
         super(context);
@@ -21,9 +19,9 @@ public class VisualizerSurfaceView extends GLSurfaceView {
     }
 
     public void setRenderer(VisualizerRenderer inputRenderer, float inputDensity, int vertexArraySize) {
-//        this.density = inputDensity;
         VisualizerModel.getInstance().renderer = inputRenderer;
-        VisualizerModel.getInstance().currentVisualizer = new VisOne(context);
+        VisualizerModel.getInstance().initVisualizers(this.context);
+        VisualizerModel.getInstance().currentVisualizer = VisualizerModel.getInstance().visOne;
 //        VisualizerModel.getInstance().currentVisualizer = new VisTwo(context);
         super.setRenderer(VisualizerModel.getInstance().renderer);
     }

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerSurfaceView.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerSurfaceView.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.opengl.GLSurfaceView;
 import android.util.AttributeSet;
 
-
 public class VisualizerSurfaceView extends GLSurfaceView {
 
     private Context context; //This exists so that we can read in the glsl files
@@ -19,10 +18,11 @@ public class VisualizerSurfaceView extends GLSurfaceView {
     }
 
     public void setRenderer(VisualizerRenderer inputRenderer, float inputDensity, int vertexArraySize) {
+
         VisualizerModel.getInstance().renderer = inputRenderer;
         VisualizerModel.getInstance().initVisualizers(this.context);
         VisualizerModel.getInstance().currentVisualizer = VisualizerModel.getInstance().visOne;
-//        VisualizerModel.getInstance().currentVisualizer = new VisTwo(context);
+
         super.setRenderer(VisualizerModel.getInstance().renderer);
     }
 

--- a/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerSurfaceView.java
+++ b/app/src/main/java/com/example/colecofer/android_audio_visualizer/VisualizerSurfaceView.java
@@ -9,7 +9,7 @@ public class VisualizerSurfaceView extends GLSurfaceView {
 
 //    private static float density;
 
-    private Context context;
+    static Context context;
 
     public VisualizerSurfaceView(Context context) {
         super(context);


### PR DESCRIPTION
Visualizers now switch!
Refactors VisualizerModel so that it has instances of VisOne, VisTwo, VisThree... 
This way we can initialize each one when the GL Surface is created, and it also allows us to keep that information in each class rather than having to reinitialize it. 
There is a constant in Constants.java that allows you to disable switching, and also set the time to have it switch for debugging.